### PR TITLE
changes after audit:

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -3,13 +3,13 @@ seeds = true
 skip-lint = false
 
 [programs.localnet]
-wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
+wbtc = "BkeUQWpHeYQDTynE3q3XjWVnmgE6WGoWgDvjfc5aSPMo"
 
 [programs.devnet]
-wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
+wbtc = "BkeUQWpHeYQDTynE3q3XjWVnmgE6WGoWgDvjfc5aSPMo"
 
 [programs.mainnet]
-wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
+wbtc = "BkeUQWpHeYQDTynE3q3XjWVnmgE6WGoWgDvjfc5aSPMo"
 
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -3,13 +3,13 @@ seeds = true
 skip-lint = false
 
 [programs.localnet]
-wbtc = "5t659YCpvc9cSMNtZxDY9tpa3WArKpwe1eqPBKBaa8Rx"
+wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
 
 [programs.devnet]
-wbtc = "5t659YCpvc9cSMNtZxDY9tpa3WArKpwe1eqPBKBaa8Rx"
+wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
 
 [programs.mainnet]
-wbtc = "5t659YCpvc9cSMNtZxDY9tpa3WArKpwe1eqPBKBaa8Rx"
+wbtc = "Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk"
 
 [test.validator]
 url = "https://api.mainnet-beta.solana.com"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This program will have two main authorities: the `authority` is capable of chang
 
 Devnet
 
-program - 5t659YCpvc9cSMNtZxDY9tpa3WArKpwe1eqPBKBaa8Rx
+program - Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk
 
-mint - 7skMX8xAbowPpeahc4Zipgcv3cUbT88Jspz8gfeH8s6D
+mint - NgTvvdb9mzPWcpyQL7dmNAoJZXtBEUyqtBvbr5RdzU3
 
 small dao - 49kUge8LHR6FoYEQqE7fq8UkZTE3ouLDeFeH8NmaxKBN
 
@@ -37,6 +37,7 @@ In order to make indexing easier, there are two main events surrouding the main 
 The following instructions either create or set basic functioning paramethers:
 
 * initialize - creates the `Config` account, and the token mint. Sets the two authorities, custodian info and mint decimals.
+* claim_authority - acts as a security buffer after changing the authority, in case of a wrongly typed addresses, the previous authority can call `set_authority` again. On initialize, the previous authority is set as the signer of `initialize`, and should be the calling `set_authority` if unable to call `claim_authority` after `initialize`
 * create_merchant - creates a `Merchant`. Requires the merchant wallet and btc address.
 * delete_merchant - deletes a `Merchant`.
 * set_authority - changes the authority address.
@@ -81,6 +82,7 @@ The following table shows the permissions for calling each instruction:
 | approve_redeem_request       |           |                    |          |     x     |
 |                              |           |                    |          |           |
 | set_authority                |     x     |                    |          |           |
+| claim_authority              |the new one|                    |          |           |
 | set_merchant_authority       |     x     |                    |          |           |
 | set_custodian                |     x     |                    |          |     x     |
 | set_custodian_btc_address    |           |                    |          |     x     |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This program will have two main authorities: the `authority` is capable of chang
 
 Devnet
 
-program - Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk
+program - BkeUQWpHeYQDTynE3q3XjWVnmgE6WGoWgDvjfc5aSPMo
 
-mint - NgTvvdb9mzPWcpyQL7dmNAoJZXtBEUyqtBvbr5RdzU3
+mint - Hb5pJ53KeUPCkUvaDZm7Y7WafEjuP1xjD4owaXksJ86R
 
 small dao - 49kUge8LHR6FoYEQqE7fq8UkZTE3ouLDeFeH8NmaxKBN
 
@@ -42,7 +42,7 @@ The following instructions either create or set basic functioning paramethers:
 * delete_merchant - deletes a `Merchant`.
 * set_authority - changes the authority address.
 * set_merchant_authority - changes the `merchant_authority` address.
-* set_custodian_btc_address - changes the custodian btc address stored in the `Config` account.
+* set_custodian_btc_address - changes the custodian btc deposit address stored in a given `Merchant` account.
 * set_custodian - changes the wallet that the custodian can use to interact with the program.
 * set_merchant_btc_address - changes the stored btc address for a given `Merchant`.
 

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -10,7 +10,10 @@ import {
 } from "@coral-xyz/anchor";
 import { Wbtc } from "../../target/types/wbtc";
 import { PublicKey, Keypair } from "@solana/web3.js";
-import { createAssociatedTokenAccount, getOrCreateAssociatedTokenAccount } from "@solana/spl-token";
+import {
+  createAssociatedTokenAccount,
+  getOrCreateAssociatedTokenAccount,
+} from "@solana/spl-token";
 import { readFileSync } from "fs";
 import Squads from "@sqds/sdk";
 
@@ -206,31 +209,29 @@ export class WbtcClient {
   async claimAuthorityWithSquads(
     multisigAddress: PublicKey,
     approve: boolean
-    ): Promise<PublicKey> {
-      const cfg = await this.getConfig();
-  
-      const msTx = await this.squads.createTransaction(multisigAddress, 1);
-  
-      const ixBuilder = this.program.methods
-        .claimAuthority()
-        .accounts({
-          config: this.configKey,
-          newAuthority: cfg.newAuthority,
-        });
-  
-      const msIx = await this.squads.addInstruction(
-        msTx.publicKey,
-        await ixBuilder.instruction()
-      );
-  
-      const fin = await this.squads.activateTransaction(msTx.publicKey);
-  
-      if (approve) await this.squads.approveTransaction(msTx.publicKey);
-  
-      console.log("Squads transaction: ", msTx.publicKey);
-      console.log("Squads instruction: ", msIx.publicKey);
-  
-      return msTx.publicKey;
+  ): Promise<PublicKey> {
+    const cfg = await this.getConfig();
+
+    const msTx = await this.squads.createTransaction(multisigAddress, 1);
+
+    const ixBuilder = this.program.methods.claimAuthority().accounts({
+      config: this.configKey,
+      newAuthority: cfg.newAuthority,
+    });
+
+    const msIx = await this.squads.addInstruction(
+      msTx.publicKey,
+      await ixBuilder.instruction()
+    );
+
+    const fin = await this.squads.activateTransaction(msTx.publicKey);
+
+    if (approve) await this.squads.approveTransaction(msTx.publicKey);
+
+    console.log("Squads transaction: ", msTx.publicKey);
+    console.log("Squads instruction: ", msIx.publicKey);
+
+    return msTx.publicKey;
   }
 
   async createMerchant(
@@ -575,10 +576,10 @@ export class WbtcClient {
     return msTx.publicKey;
   }
 
-  async setCustodianBtcAddress(newBtcAddress: string): Promise<string> {
+  async setCustodianBtcAddress(newBtcAddress: string, merchant: PublicKey): Promise<string> {
     return this.program.methods
       .setCustodianBtcAddress(newBtcAddress)
-      .accounts({ config: this.configKey })
+      .accounts({ config: this.configKey, merchant })
       .rpc();
   }
 

--- a/programs/wbtc/src/error.rs
+++ b/programs/wbtc/src/error.rs
@@ -41,4 +41,6 @@ pub enum ErrorCode {
     InvalidNewAuthority,
     #[msg("the new custodian is invalid (collision with authority/new_authority")]
     InvalidNewCustodian,
+    #[msg("the custodian btc deposit address is invalid for the given merchant")]
+    InvalidCustodianBtcAddress,
 }

--- a/programs/wbtc/src/error.rs
+++ b/programs/wbtc/src/error.rs
@@ -29,8 +29,16 @@ pub enum ErrorCode {
     AddressTooLong,
     #[msg("the given address length is too short for a btc address (<26 characters)")]
     AddressTooShort,
+    #[msg("the address contains invalid (non-ascii) characters")]
+    InvalidAddressCharacters,
+    #[msg("the transaction contains invalid (non-ascii) characters")]
+    InvalidTransactionCharacters,
     #[msg("invalid reamining accounts on initialise")]
     InvalidInitialiseRemainingAccounts,
     #[msg("invalid token amount")]
     InvalidAmount,
+    #[msg("the new authority is invalid (collision with custodian)")]
+    InvalidNewAuthority,
+    #[msg("the new custodian is invalid (collision with authority/new_authority")]
+    InvalidNewCustodian,
 }

--- a/programs/wbtc/src/instructions/approve_redeem_request.rs
+++ b/programs/wbtc/src/instructions/approve_redeem_request.rs
@@ -24,7 +24,7 @@ pub struct ApproveRedeemRequestAccounts<'info> {
     pub merchant: Account<'info, Merchant>,
 
     #[account(mut,
-        close = merchant,
+        close = merchant_authority,
         has_one = merchant,
     )]
     pub redeem_request: Account<'info, RedeemRequest>,

--- a/programs/wbtc/src/instructions/claim_authority.rs
+++ b/programs/wbtc/src/instructions/claim_authority.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::error::ErrorCode;
+use crate::state::Config;
+
+#[derive(Accounts)]
+pub struct ClaimAuthorityAccounts<'info> {
+    #[account(mut)]
+    pub new_authority: Signer<'info>,
+
+    #[account(mut, has_one = new_authority @ ErrorCode::InvalidAuthority)]
+    pub config: Account<'info, Config>,
+}
+
+pub fn handler(ctx: Context<ClaimAuthorityAccounts>) -> Result<()> {
+    ctx.accounts.config.authority = ctx.accounts.new_authority.key();
+    ctx.accounts.config.new_authority = Pubkey::default();
+
+    Ok(())
+}

--- a/programs/wbtc/src/instructions/create_mint_request.rs
+++ b/programs/wbtc/src/instructions/create_mint_request.rs
@@ -54,6 +54,7 @@ pub fn handler(ctx: Context<CreateMintRequestAccounts>, args: CreateMintRequestA
     mint_request.transaction_id = args.transaction_id;
     mint_request.client_token_account = ctx.accounts.client_token_account.key();
     mint_request.req_id = config.mint_req_counter;
+    mint_request.timestamp = Clock::get()?.unix_timestamp as u64;
 
     config.mint_req_counter = config.mint_req_counter.checked_add(1).unwrap();
 

--- a/programs/wbtc/src/instructions/create_mint_request.rs
+++ b/programs/wbtc/src/instructions/create_mint_request.rs
@@ -5,7 +5,7 @@ use crate::constants::MINT_REQUEST_SEED_PREFIX;
 use crate::error::ErrorCode;
 use crate::events::{EventKind, MintEvent};
 use crate::state::{Config, Merchant, MintRequest};
-use crate::utils::validate_btc_transaction;
+use crate::utils::{validate_btc_address, validate_btc_transaction};
 
 #[derive(Accounts)]
 #[instruction(args: CreateMintRequestArgs)]
@@ -46,6 +46,11 @@ pub fn handler(ctx: Context<CreateMintRequestAccounts>, args: CreateMintRequestA
 
     require!(config.mint_enabled, ErrorCode::MintingDisabled);
     require!(merchant.enabled, ErrorCode::MerchantDisabled);
+
+    require!(
+        validate_btc_address(&merchant.custodian_btc_address).is_ok(),
+        ErrorCode::InvalidCustodianBtcAddress
+    );
 
     validate_btc_transaction(&args.transaction_id)?;
 

--- a/programs/wbtc/src/instructions/initialize.rs
+++ b/programs/wbtc/src/instructions/initialize.rs
@@ -3,7 +3,6 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::invoke_signed;
 use anchor_spl::token::{Mint, Token};
 
-#[cfg(not(feature = "localnet"))]
 use crate::error::ErrorCode;
 #[cfg(not(feature = "localnet"))]
 use crate::program::Wbtc;
@@ -65,7 +64,17 @@ pub fn handler(ctx: Context<InitializeAccounts>, args: InitializeArgs) -> Result
 
     validate_upgrade_authority(ctx.accounts.authority.key(), ctx.remaining_accounts)?;
 
-    cfg.authority = args.authority;
+    require!(
+        ctx.accounts.authority.key() != args.custodian,
+        ErrorCode::InvalidNewCustodian
+    );
+    require!(
+        args.authority != args.custodian,
+        ErrorCode::InvalidNewAuthority
+    );
+
+    cfg.authority = ctx.accounts.authority.key();
+    cfg.new_authority = args.authority;
     cfg.custodian = args.custodian;
     cfg.custodian_btc_address = args.custodian_btc_address;
     cfg.merchant_authority = args.merchant_authority;

--- a/programs/wbtc/src/instructions/initialize.rs
+++ b/programs/wbtc/src/instructions/initialize.rs
@@ -8,7 +8,6 @@ use crate::error::ErrorCode;
 use crate::program::Wbtc;
 
 use crate::gen_mint_seeds;
-use crate::utils::validate_btc_address;
 use crate::{constants::CONFIG_SEED_PREFIX, constants::MINT_SEED_PREFIX, state::Config};
 
 #[derive(Accounts)]
@@ -51,7 +50,6 @@ pub struct InitializeArgs {
     pub authority: Pubkey,
     pub merchant_authority: Pubkey,
     pub custodian: Pubkey,
-    pub custodian_btc_address: String,
     pub name: String,
     pub symbol: String,
     pub uri: String,
@@ -59,8 +57,6 @@ pub struct InitializeArgs {
 
 pub fn handler(ctx: Context<InitializeAccounts>, args: InitializeArgs) -> Result<()> {
     let cfg = &mut ctx.accounts.config;
-
-    validate_btc_address(&args.custodian_btc_address)?;
 
     validate_upgrade_authority(ctx.accounts.authority.key(), ctx.remaining_accounts)?;
 
@@ -76,7 +72,6 @@ pub fn handler(ctx: Context<InitializeAccounts>, args: InitializeArgs) -> Result
     cfg.authority = ctx.accounts.authority.key();
     cfg.new_authority = args.authority;
     cfg.custodian = args.custodian;
-    cfg.custodian_btc_address = args.custodian_btc_address;
     cfg.merchant_authority = args.merchant_authority;
     cfg.mint = ctx.accounts.mint.key();
     cfg.mint_req_counter = 0;

--- a/programs/wbtc/src/instructions/mod.rs
+++ b/programs/wbtc/src/instructions/mod.rs
@@ -1,6 +1,7 @@
 pub mod approve_mint_request;
 pub mod approve_redeem_request;
 pub mod cancel_mint_request;
+pub mod claim_authority;
 pub mod create_merchant;
 pub mod create_mint_request;
 pub mod create_redeem_request;
@@ -18,6 +19,7 @@ pub mod toggle_merchant_enabled;
 pub use approve_mint_request::*;
 pub use approve_redeem_request::*;
 pub use cancel_mint_request::*;
+pub use claim_authority::*;
 pub use create_merchant::*;
 pub use create_mint_request::*;
 pub use create_redeem_request::*;

--- a/programs/wbtc/src/instructions/set_authority.rs
+++ b/programs/wbtc/src/instructions/set_authority.rs
@@ -12,11 +12,12 @@ pub struct SetAuthorityAccounts<'info> {
     pub config: Account<'info, Config>,
 
     /// CHECK: nothing to check here, its just the new authority address
+    #[account(constraint = new_authority.key() != config.custodian @ ErrorCode::InvalidNewAuthority)]
     pub new_authority: AccountInfo<'info>,
 }
 
 pub fn handler(ctx: Context<SetAuthorityAccounts>) -> Result<()> {
-    ctx.accounts.config.authority = ctx.accounts.new_authority.key();
+    ctx.accounts.config.new_authority = ctx.accounts.new_authority.key();
 
     Ok(())
 }

--- a/programs/wbtc/src/instructions/set_custodian.rs
+++ b/programs/wbtc/src/instructions/set_custodian.rs
@@ -15,6 +15,10 @@ pub struct SetCustodianAccounts<'info> {
     pub config: Account<'info, Config>,
 
     /// CHECK: nothing to check here, its just the new authority address
+    #[account(
+        constraint = new_custodian.key() != config.authority 
+        && new_custodian.key() != config.new_authority @ ErrorCode::InvalidNewCustodian
+    )]
     pub new_custodian: AccountInfo<'info>,
 }
 

--- a/programs/wbtc/src/instructions/set_custodian_btc_address.rs
+++ b/programs/wbtc/src/instructions/set_custodian_btc_address.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::error::ErrorCode;
-use crate::state::Config;
+use crate::state::{Config, Merchant};
 use crate::utils::validate_btc_address;
 
 #[derive(Accounts)]
@@ -11,6 +11,9 @@ pub struct SetCustodianBtcAddressAccounts<'info> {
 
     #[account(mut, has_one = custodian @ ErrorCode::InvalidCustodian)]
     pub config: Account<'info, Config>,
+
+    #[account(mut)]
+    pub merchant: Account<'info, Merchant>,
 }
 
 pub fn handler(
@@ -24,7 +27,7 @@ pub fn handler(
 
     validate_btc_address(&new_custodian_btc_address)?;
 
-    ctx.accounts.config.custodian_btc_address = new_custodian_btc_address;
+    ctx.accounts.merchant.custodian_btc_address = new_custodian_btc_address;
 
     Ok(())
 }

--- a/programs/wbtc/src/instructions/set_merchant_btc_address.rs
+++ b/programs/wbtc/src/instructions/set_merchant_btc_address.rs
@@ -15,11 +15,11 @@ pub struct SetMerchantBtcAddressAccounts<'info> {
 
 pub fn handler(
     ctx: Context<SetMerchantBtcAddressAccounts>,
-    new_merchant_btc_addresss: String,
+    new_merchant_btc_address: String,
 ) -> Result<()> {
-    validate_btc_address(&new_merchant_btc_addresss)?;
+    validate_btc_address(&new_merchant_btc_address)?;
 
-    ctx.accounts.merchant.btc_address = new_merchant_btc_addresss;
+    ctx.accounts.merchant.btc_address = new_merchant_btc_address;
 
     Ok(())
 }

--- a/programs/wbtc/src/lib.rs
+++ b/programs/wbtc/src/lib.rs
@@ -11,7 +11,7 @@ pub use instructions::*;
 
 use anchor_lang::prelude::*;
 
-declare_id!("5t659YCpvc9cSMNtZxDY9tpa3WArKpwe1eqPBKBaa8Rx");
+declare_id!("Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk");
 
 #[program]
 pub mod wbtc {
@@ -20,6 +20,10 @@ pub mod wbtc {
 
     pub fn initialize(ctx: Context<InitializeAccounts>, args: InitializeArgs) -> Result<()> {
         instructions::initialize::handler(ctx, args)
+    }
+
+    pub fn claim_authority(ctx: Context<ClaimAuthorityAccounts>) -> Result<()> {
+        instructions::claim_authority::handler(ctx)
     }
 
     pub fn set_authority(ctx: Context<SetAuthorityAccounts>) -> Result<()> {

--- a/programs/wbtc/src/lib.rs
+++ b/programs/wbtc/src/lib.rs
@@ -11,7 +11,7 @@ pub use instructions::*;
 
 use anchor_lang::prelude::*;
 
-declare_id!("Fwc8BsPm6ktThT49CmcpXUpG5MhBTTnvUyRo4yTdEFDk");
+declare_id!("BkeUQWpHeYQDTynE3q3XjWVnmgE6WGoWgDvjfc5aSPMo");
 
 #[program]
 pub mod wbtc {

--- a/programs/wbtc/src/state.rs
+++ b/programs/wbtc/src/state.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-static_assertions::const_assert!(Config::LEN > std::mem::size_of::<Config>());
+static_assertions::const_assert_eq!(Config::LEN, std::mem::size_of::<Config>());
 #[account]
 #[derive(Debug)]
 pub struct Config {
@@ -8,7 +8,6 @@ pub struct Config {
     pub new_authority: Pubkey,
     pub merchant_authority: Pubkey,
     pub custodian: Pubkey,
-    pub custodian_btc_address: String,
     pub mint: Pubkey,
     pub mint_req_counter: u64,
     pub redeem_req_counter: u64,
@@ -16,6 +15,7 @@ pub struct Config {
     pub redeem_enabled: bool,
     pub custodian_enabled: bool,
     pub bump: u8,
+    pub _padding: [u8; 4],
 }
 
 static_assertions::const_assert!(Merchant::LEN > std::mem::size_of::<Merchant>());
@@ -24,6 +24,7 @@ static_assertions::const_assert!(Merchant::LEN > std::mem::size_of::<Merchant>()
 pub struct Merchant {
     pub authority: Pubkey,
     pub btc_address: String,
+    pub custodian_btc_address: String,
     pub enabled: bool,
 }
 
@@ -50,15 +51,15 @@ pub struct RedeemRequest {
 }
 
 impl Config {
-    pub const LEN: usize = 4 * 32 + 128 + 2 * 8 + 3;
+    pub const LEN: usize = 5 * 32 + 2 * 8 + 3 + 1 + 4;
 }
 
 impl Merchant {
-    pub const LEN: usize = 32 + 128 + 1;
+    pub const LEN: usize = 32 + 128 + 128 + 1;
 }
 
 impl MintRequest {
-    pub const LEN: usize = 3 * 32 + 128 + 3 * 8 + 128;
+    pub const LEN: usize = 2 * 32 + 128 + 3 * 8;
 }
 
 impl RedeemRequest {

--- a/programs/wbtc/src/state.rs
+++ b/programs/wbtc/src/state.rs
@@ -5,6 +5,7 @@ static_assertions::const_assert!(Config::LEN > std::mem::size_of::<Config>());
 #[derive(Debug)]
 pub struct Config {
     pub authority: Pubkey,
+    pub new_authority: Pubkey,
     pub merchant_authority: Pubkey,
     pub custodian: Pubkey,
     pub custodian_btc_address: String,

--- a/programs/wbtc/src/utils.rs
+++ b/programs/wbtc/src/utils.rs
@@ -15,6 +15,10 @@ pub fn validate_btc_address(address: &String) -> Result<()> {
         address.len() >= BTC_ADDRESS_MIN_LEN,
         ErrorCode::AddressTooShort
     );
+    require!(
+        address.chars().all(|c| c.is_ascii_alphanumeric()),
+        ErrorCode::InvalidAddressCharacters
+    );
     Ok(())
 }
 
@@ -23,6 +27,11 @@ pub fn validate_btc_transaction(transaction: &String) -> Result<()> {
     require!(
         transaction.len() == BTC_TRANSACTION_LEN,
         ErrorCode::InvalidTransactionLength
+    );
+
+    require!(
+        transaction.chars().all(|c| c.is_ascii_alphanumeric()),
+        ErrorCode::InvalidTransactionCharacters
     );
     Ok(())
 }

--- a/tests/wbtc.ts
+++ b/tests/wbtc.ts
@@ -160,6 +160,12 @@ describe("wbtc", () => {
       })
       .accounts({ metadata, tokenMetadataProgram: TOKEN_METADATA_PROGRAM })
       .rpcAndKeys();
+
+    await program.methods
+      .claimAuthority()
+      .accounts({ config, newAuthority: authority.publicKey })
+      .signers([authority])
+      .rpc();
   });
 
   it("creates merchant", async () => {
@@ -307,6 +313,24 @@ describe("wbtc", () => {
       assert.strictEqual(e.error.errorCode.code, "InvalidTransactionLength");
     }
 
+    try {
+      const mintReq = await program.methods
+        .createMintRequest({
+          amount: new BN(100000),
+          transactionId: "!2e62d55f27d033ca8e5e296f1637517fdec92e48b51eb7eb64a9beb500a88bb",
+        })
+        .accounts({
+          config,
+          merchantInfo,
+          authority: merchant.publicKey,
+          clientTokenAccount,
+        })
+        .signers([merchant])
+        .rpc();
+    } catch (e) {
+      assert.strictEqual(e.error.errorCode.code, "InvalidTransactionCharacters");
+    }
+
     const mintReq = await program.methods
       .createMintRequest({
         amount: new BN(100000),
@@ -445,8 +469,6 @@ describe("wbtc", () => {
 
     let mintReq = res.pubkeys.mintRequest;
 
-    console.log("blah");
-
     console.log("custodian: ", custodian.publicKey.toString());
     console.log("mintReq: ", mintReq.toString());
     console.log("merchantInfo: ", merchantInfo.toString());
@@ -479,7 +501,6 @@ describe("wbtc", () => {
       .accounts({ config, authority: authority.publicKey })
       .signers([authority])
       .rpc();
-    console.log(" blah 2");
 
     await assertInvalidTransaction(
       program.methods
@@ -551,8 +572,6 @@ describe("wbtc", () => {
 
     let mintReq = res.pubkeys.mintRequest;
 
-    console.log("blah");
-
     console.log("custodian: ", custodian.publicKey.toString());
     console.log("mintReq: ", mintReq.toString());
     console.log("merchantInfo: ", merchantInfo.toString());
@@ -584,7 +603,6 @@ describe("wbtc", () => {
       .accounts({ config, authority: authority.publicKey })
       .signers([authority])
       .rpc();
-    console.log(" blah 2");
 
     await program.methods
       .rejectMintRequest()


### PR DESCRIPTION
- new claim_authority ix
- additional verification of btc transaction hashes and keys
- enforcing authority & custodian are different
- fixed redeem account rent going to wrong account
- btc deposit address removed from config into merchant accounts, as the custodian uses different wallets on a merchant by merchant basis